### PR TITLE
Reading back the rendered data works again

### DIFF
--- a/src/examples/meshviewer/meshview.cpp
+++ b/src/examples/meshviewer/meshview.cpp
@@ -251,8 +251,8 @@ void FboRenderer::render()
 		// Draw the object buffer
 		{
 			_idBuffer->bind(_engine.get());
-			_idBuffer->clear(0, Eigen::Vector4i{ 0, 0, 0, 0 });
-			_idBuffer->clear(0, 1);
+			_idBuffer->clear(0, Eigen::Vector4i{ -1, -1, 0, 0 });
+			_idBuffer->clear(1.0f);
 
 			auto volumes = scene->entityManager()->get<GPUVolumeMesh>();
 			if (!volumes->empty())

--- a/src/libs/vcl.graphics/vcl/graphics/runtime/framebuffer.cpp
+++ b/src/libs/vcl.graphics/vcl/graphics/runtime/framebuffer.cpp
@@ -91,7 +91,7 @@ namespace Vcl { namespace Graphics { namespace Runtime
 	}
 	void GBuffer::clear(float depth)
 	{
-		glClearBufferfi(GL_DEPTH, 0, depth, 0);
+		glClearBufferfv(GL_DEPTH, 0, &depth);
 	}
 	void GBuffer::clear(int stencil)
 	{


### PR DESCRIPTION
Clearing depth buffer correctly allows to render the Id values again