### PR TITLE
Changes and bugfixes for clang-cl compatibility

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,16 +25,11 @@
 version: "{build}"
 
 image:
-  - Visual Studio 2015
   - Visual Studio 2017
 
 platform: 
   - Win32
   - x64
-
-branches:
-  only:
-    - master
 
 configuration:
   - Debug
@@ -43,31 +38,71 @@ configuration:
 environment:
   MSVC_DEFAULT_OPTIONS: ON
   
-  matrix:
-    - vec_type: "SSE 2"
-    - vec_type: "SSE 3"
-    - vec_type: "SSE 4.1"
-    - vec_type: "SSE 4.2"
-    - vec_type: "AVX"
+  # Custom cmake version
+  cmake: C:\projects\cmake-3.10.1-win64-x64\bin\cmake.exe
+  
+  matrix:	
+    - tool_set: "v140"
+      vec_type: "SSE 2"
+    - tool_set: "v140"
+      vec_type: "SSE 3"
+    - tool_set: "v140"
+      vec_type: "SSE 4.1"
+    - tool_set: "v140"
+      vec_type: "SSE 4.2"
+    - tool_set: "v140"
+      vec_type: "AVX"
+
+    #- tool_set: "v141"
+    #  vec_type: "SSE 2"
+    #- tool_set: "v141"
+    #  vec_type: "SSE 3"
+    #- tool_set: "v141"
+    #  vec_type: "SSE 4.1"
+    - tool_set: "v141"
+      vec_type: "SSE 4.2"
+    - tool_set: "v141"
+      vec_type: "AVX"
+
+    #- tool_set: "LLVM-vs2014"
+    #  vec_type: "SSE 2"
+    #- tool_set: "LLVM-vs2014"
+    #  vec_type: "SSE 3"
+    #- tool_set: "LLVM-vs2014"
+    #  vec_type: "SSE 4.1"
+    - tool_set: "LLVM-vs2014"
+      vec_type: "SSE 4.2"
+    - tool_set: "LLVM-vs2014"
+      vec_type: "AVX"
+
+branches:
+  only:
+    - master
 
 init:
-  - cmd: cmake --version
   - cmd: msbuild /version
 
 clone_folder: C:\projects\vcl
 
 install:
   - cmd: git submodule update --init --recursive
-
+  
+  - ps: wget https://cmake.org/files/v3.10/cmake-3.10.1-win64-x64.zip -OutFile cmake.zip
+  - cmd: 7z x cmake.zip -o"C:\projects" -y > nul # will extract to cmake-3.10.1-win64-x64\
+  - cmd: '%cmake% --version'
+  
+  # Download and install clang
+  - if "%tool_set%"=="LLVM-vs2014" appveyor DownloadFile http://releases.llvm.org/5.0.1/LLVM-5.0.1-win64.exe -FileName llvm-installer.exe
+  - if "%tool_set%"=="LLVM-vs2014" start /WAIT llvm-installer.exe /S /D=C:\"Program Files\LLVM"
+  - if "%tool_set%"=="LLVM-vs2014" cmd: clang --version
+  
 before_build:
   - cmd: cd C:\projects\vcl
   - cmd: md build
   - cmd: cd build
-  - cmd: if "%platform%"=="Win32" if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2015" set CMAKE_GENERATOR_NAME=Visual Studio 14 2015
-  - cmd: if "%platform%"=="x64"   if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2015" set CMAKE_GENERATOR_NAME=Visual Studio 14 2015 Win64
   - cmd: if "%platform%"=="Win32" if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2017" set CMAKE_GENERATOR_NAME=Visual Studio 15 2017
   - cmd: if "%platform%"=="x64"   if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2017" set CMAKE_GENERATOR_NAME=Visual Studio 15 2017 Win64
-  - cmd: cmake -G "%CMAKE_GENERATOR_NAME%" -DVCL_CODE_COVERAGE:BOOL=off -DVCL_ENABLE_CORE_GUIDELINE_CHECKER:BOOL=off -DVCL_BUILD_BENCHMARKS:BOOL=off -DVCL_BUILD_TESTS:BOOL=on -DVCL_BUILD_TOOLS:BOOL=off -DVCL_BUILD_EXAMPLES:BOOL=off -DVCL_VECTORIZE:STRING="%vec_type%" ../src
+  - cmd: '%cmake% -G "%CMAKE_GENERATOR_NAME%" -T "%tool_set%" -DVCL_CODE_COVERAGE:BOOL=off -DVCL_ENABLE_CORE_GUIDELINE_CHECKER:BOOL=off -DVCL_BUILD_BENCHMARKS:BOOL=off -DVCL_BUILD_TESTS:BOOL=on -DVCL_BUILD_TOOLS:BOOL=off -DVCL_BUILD_EXAMPLES:BOOL=off -DVCL_VECTORIZE:STRING="%vec_type%" ../src'
 
 build_script:
   - msbuild C:\projects\vcl\build\tests\vcl.components\vcl_components_test.sln

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,6 +14,12 @@ SET(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# For clang on Windows globally ignore unused commandline arguments
+if (WIN32 AND ${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=unused-command-line-argument -Wno-error=deprecated-declarations")
+	add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+endif()
+
 ################################################################################
 # Add the externals
 ################################################################################

--- a/src/benchmarks/CMakeLists.txt
+++ b/src/benchmarks/CMakeLists.txt
@@ -1,6 +1,9 @@
 
-# Performance benchmarks for mutexes
-SUBDIRS(mutex)
+# For clang on Windows globally ignore unused commandline arguments
+if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang" AND NOT WIN32)
+	# Performance benchmarks for mutexes
+	SUBDIRS(mutex)
+endif()
 
 # Performance benchmarks for 3x3 Eigen deompositions
 SUBDIRS(eigen33performance)

--- a/src/libs/vcl.core/vcl/config/compiler.h
+++ b/src/libs/vcl.core/vcl/config/compiler.h
@@ -104,7 +104,7 @@
 #	endif
 
 #elif defined VCL_COMPILER_GNU || defined VCL_COMPILER_CLANG
-#	if defined __i686__
+#	if defined __i386__ || defined __i686__
 #		define VCL_ARCH_X86
 #	endif
 

--- a/src/libs/vcl.core/vcl/core/simd/float8_avx.h
+++ b/src/libs/vcl.core/vcl/core/simd/float8_avx.h
@@ -39,7 +39,7 @@
 namespace Vcl
 {
 	template<>
-	class VectorScalar<float, 8>
+	class alignas(32) VectorScalar<float, 8>
 	{
 	public:
 		VCL_STRONG_INLINE VectorScalar() = default;

--- a/src/tests/vcl.geometry/distance.cpp
+++ b/src/tests/vcl.geometry/distance.cpp
@@ -73,7 +73,7 @@ TEST(PointTriangleDistance, Simple)
 
 	typedef Eigen::Matrix<real_t, 3, 1> vector3_t;
 
-	using WideVector = std::vector<real_t, Vcl::Core::Allocator<real_t, Vcl::Core::AlignedAllocPolicy<real_t>>>;
+	using WideVector = std::vector<real_t, Vcl::Core::Allocator<real_t, Vcl::Core::AlignedAllocPolicy<real_t, 32>>>;
 
 	// Reference triangle
 	Eigen::Vector3f ref_a{ 1, 0, 0 };


### PR DESCRIPTION
Adapts build configuration for clang-cl. In addition configures Appveyor to download clang 5 and compatible cmake 3.10